### PR TITLE
Whitespace example

### DIFF
--- a/source/github_tips/whitespace.md
+++ b/source/github_tips/whitespace.md
@@ -1,20 +1,22 @@
-{% extends "source/md.html" %}
-{% block md %}
-
+{% extends "source/md.html" %}  
+{% block md %}  
+  
 ## Whitespace options
-
-### Git
-
-git can ignore whitespace in a diff:
-
+  
+### Git  
+  
+git can ignore whitespace in a diff:  
+  
 ```bash
 git diff -w
 ```
 
 ### Github
 
-Add `?w=1` to any diff URL and GitHub will strip the whitespace.
+  Add `?w=1` to any diff URL and GitHub will strip the whitespace.
 
-TODO: Add link to my whitespace example branch here.
+  TODO: Add link to my whitespace example branch here.
+
+  Only one real change.
 
 {% endblock %}


### PR DESCRIPTION
This is an example of using the `?w=1` URL trick in Github.  [Original](https://github.com/bholladay/github-is-awesomeness/pull/3) vs [whitespace ignored](https://github.com/bholladay/github-is-awesomeness/pull/3?w=1)
